### PR TITLE
Bugfix for MongoDB connection timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Make sure to replace the values for GATEWAY_ID with your BPI Key, and for GATEWA
 ```sh
 docker run -dit \
     --name overledger-network-gateway \
+    --network ovl-ent \
     -p 8080:8080 -p 11337:11337 \
     -e GATEWAY_ID="bpiKey" \
     -e GATEWAY_HOST="127.0.0.1" \


### PR DESCRIPTION
Added --network ovl-net to gateway setup, so both MongoDB and OVL run in the same docker network. Argument was missing from gateway.